### PR TITLE
Using bare variables is deprecated

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,7 @@
   file:
     path: "{{ item.value.dest }}"
     state: directory
-  with_dict: htop_htoprc_destinations
+  with_dict: "{{ htop_htoprc_destinations }}"
   tags: [configuration, htop, htop-configuration]
 
 - name: create configuration file
@@ -23,5 +23,5 @@
     group: "{{ item.value.group | default(item.value.owner) | default('root') }}"
     mode: "{{ item.value.mode | default('0644') }}"
     force: "{{ 'yes' if htop_replace_htoprc else 'no' }}"
-  with_dict: htop_htoprc_destinations
+  with_dict: "{{ htop_htoprc_destinations }}"
   tags: [configuration, htop, htop-configuration]


### PR DESCRIPTION
to get rid of this warning message:

````
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment 
value uses the full variable syntax ('{{htop_htoprc_destinations}}'). This feature will be removed in a 
future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
````
